### PR TITLE
Email builder - send preview button

### DIFF
--- a/coronavirus-utilities.php
+++ b/coronavirus-utilities.php
@@ -22,7 +22,10 @@ define( 'CORONAVIRUS_UTILS__PLUGIN_STATIC_URL', CORONAVIRUS_UTILS__PLUGIN_URL . 
 define( 'CORONAVIRUS_UTILS__PLUGIN_CSS_URL', CORONAVIRUS_UTILS__PLUGIN_STATIC_URL . 'css/' );
 define( 'CORONAVIRUS_UTILS__PLUGIN_JS_URL', CORONAVIRUS_UTILS__PLUGIN_STATIC_URL . 'js/' );
 
+define( 'CORONAVIRUS_UTILS__DEFAULT_GMUCF_URL', 'https://gmucf.smca.ucf.edu/coronavirus/mail/?no_cache=true' );
 
+
+require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/config.php';
 require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/admin.php';
 require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/meta.php';
 require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/post-functions.php';

--- a/coronavirus-utilities.php
+++ b/coronavirus-utilities.php
@@ -28,3 +28,4 @@ require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/meta.php';
 require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/post-functions.php';
 require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/options-weekly-email.php';
 require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/api-weekly-email.php';
+require_once CORONAVIRUS_UTILS__PLUGIN_DIR . 'includes/email-send-functions.php';

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -526,7 +526,7 @@
                     "class": "",
                     "id": ""
                 },
-                "message": "<p style=\"margin-top: 0;\">Click the button below to open the email in a new tab. This page must be updated in order to see the latest changes.<\/p>\r\n<a class=\"button button-secondary button-large\" href=\"https:\/\/gmucf.smca.ucf.edu\/coronavirus\/mail\/?no_cache=true\" target=\"_blank\">Preview Email<\/a>",
+                "message": "<p style=\"margin-top: 0;\">Click the button below to open the email in a new tab. This page must be updated in order to see the latest changes.<\/p>\r\n<a id=\"preview-in-browser\" class=\"button button-secondary button-large\" href=\"#\" target=\"_blank\">Preview Email<\/a>",
                 "new_lines": "wpautop",
                 "esc_html": 0
             },

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -515,7 +515,7 @@
         "fields": [
             {
                 "key": "field_5f0e1af5b3f65",
-                "label": "",
+                "label": "View in Browser",
                 "name": "",
                 "type": "message",
                 "instructions": "",
@@ -526,9 +526,45 @@
                     "class": "",
                     "id": ""
                 },
-                "message": "<p style=\"margin-top: 0;\">Click the button below to open the email in a new tab. This page must be updated in order to see the latest changes.<\/p>\r\n<a href=\"https:\/\/gmucf.smca.ucf.edu\/coronavirus\/mail\/?no_cache=true\" target=\"_blank\" style=\"background: #fc0; padding: 8px; color: #000; text-decoration: none; font-weight: bold; display: block; text-align: center;\">Preview Email<\/a>",
+                "message": "<p style=\"margin-top: 0;\">Click the button below to open the email in a new tab. This page must be updated in order to see the latest changes.<\/p>\r\n<a class=\"button button-secondary button-large\" href=\"https:\/\/gmucf.smca.ucf.edu\/coronavirus\/mail\/?no_cache=true\" target=\"_blank\">Preview Email<\/a>",
                 "new_lines": "wpautop",
                 "esc_html": 0
+            },
+            {
+                "key": "field_5f494cca5afce",
+                "label": "Send a Test",
+                "name": "",
+                "type": "message",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "<p style=\"margin-top: 0;\">Click the button below to send a test of this email to the Preview Recipients defined below. This page must be updated in order for the latest content to be sent.<\/p>\r\n<a href=\"#send-preview\" id=\"instant-send\" class=\"button button-primary button-large\">Send Test<\/a>",
+                "new_lines": "wpautop",
+                "esc_html": 0
+            },
+            {
+                "key": "field_5f494c975afcd",
+                "label": "Preview Recipients",
+                "name": "preview_recipients",
+                "type": "textarea",
+                "instructions": "Enter a comma-separated list of email addresses to send tests to.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "maxlength": "",
+                "rows": "",
+                "new_lines": ""
             }
         ],
         "location": [

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -543,7 +543,7 @@
                     "class": "",
                     "id": ""
                 },
-                "message": "<p style=\"margin-top: 0;\">Click the button below to send a test of this email to the Preview Recipients defined below. This page must be updated in order for the latest content to be sent.<\/p>\r\n<a href=\"#send-preview\" id=\"instant-send\" class=\"button button-primary button-large\">Send Test<\/a>",
+                "message": "<p style=\"margin-top: 0;\">Click the button below to send a test of this email to the Preview Recipients defined below. <strong>Make sure you've saved your changes before clicking this button<\/strong> to ensure the latest email content is sent and that the preview recipient list is up-to-date.<\/p>\r\n<a href=\"#send-preview\" id=\"instant-send\" class=\"button button-primary button-large\">Send Test<\/a>",
                 "new_lines": "wpautop",
                 "esc_html": 0
             },

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -124,7 +124,7 @@ add_filter( 'quicktags_settings', __NAMESPACE__ . '\acf_wysiwyg_quicktags_toolba
 
 /**
  * Defines inline javascript necessary for the
- * coronavirus email's Send Preview button to function.
+ * coronavirus email's Preview Weekly Email tools to function.
  *
  * @since 1.1.0
  * @author Jim Barnes
@@ -133,6 +133,7 @@ add_filter( 'quicktags_settings', __NAMESPACE__ . '\acf_wysiwyg_quicktags_toolba
 function insert_instant_send_js() {
 	$menu_id        = OptionsWeeklyEmail\screen_id();
 	$current_screen = get_current_screen();
+	$gmucf_url      = get_option( CORONAVIRUS_THEME_CUSTOMIZER_PREFIX . 'email_gmucf_url', CORONAVIRUS_UTILS__DEFAULT_GMUCF_URL );
 
 	if ( ! $current_screen || $current_screen->id !== $menu_id ) return;
 ?>
@@ -141,6 +142,7 @@ function insert_instant_send_js() {
 		var data = {
 			action: 'instant-send'
 		};
+		var gmucf_url = '<?php echo $gmucf_url; ?>';
 
 		var onPostSuccess = function(response) {
 			var $markup = '';
@@ -168,6 +170,11 @@ function insert_instant_send_js() {
 				onPostSuccess,
 				'json'
 			);
+		});
+
+		$(document).on('ready', function() {
+			console.log('hello?');
+			$('#preview-in-browser').attr('href', gmucf_url);
 		});
 	}(jQuery));
 	</script>

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -120,3 +120,58 @@ function acf_wysiwyg_quicktags_toolbar( $qt_init, $editor_id ) {
 }
 
 add_filter( 'quicktags_settings', __NAMESPACE__ . '\acf_wysiwyg_quicktags_toolbar', 10, 2 );
+
+
+/**
+ * Defines inline javascript necessary for the
+ * coronavirus email's Send Preview button to function.
+ *
+ * @since 1.1.0
+ * @author Jim Barnes
+ * @return void
+ */
+function insert_instant_send_js() {
+	$menu_id        = OptionsWeeklyEmail\screen_id();
+	$current_screen = get_current_screen();
+
+	if ( ! $current_screen || $current_screen->id !== $menu_id ) return;
+?>
+	<script>
+	(function($) {
+		var data = {
+			action: 'instant-send'
+		};
+
+		var onPostSuccess = function(response) {
+			var $markup = '';
+			if ( response.success === true ) {
+				$markup = $(
+					'<div class="acf-admin-notice notice notice-success">' +
+						'<p>Preview of email sent.</p>' +
+					'</div>'
+				);
+			} else {
+				$markup = $(
+					'<div class="acf-admin-notice notice notice-error">' +
+						'<p>There was a problem sending the preview.</p>' +
+					'</div>'
+				);
+			}
+
+			$markup.insertAfter('.acf-settings-wrap > h1');
+		};
+
+		$('#instant-send').on('click', function() {
+			$.post(
+				ajaxurl,
+				data,
+				onPostSuccess,
+				'json'
+			);
+		});
+	}(jQuery));
+	</script>
+<?php
+}
+
+add_action( 'admin_footer', __NAMESPACE__ . '\insert_instant_send_js', 10, 1 );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -3,6 +3,7 @@
  * Admin-related functions/overrides
  */
 namespace Coronavirus\Utils\Includes\Admin;
+use Coronavirus\Utils\Includes\Config;
 use Coronavirus\Utils\Includes\OptionsWeeklyEmail;
 
 
@@ -133,7 +134,7 @@ add_filter( 'quicktags_settings', __NAMESPACE__ . '\acf_wysiwyg_quicktags_toolba
 function insert_instant_send_js() {
 	$menu_id        = OptionsWeeklyEmail\screen_id();
 	$current_screen = get_current_screen();
-	$gmucf_url      = get_option( CORONAVIRUS_THEME_CUSTOMIZER_PREFIX . 'email_gmucf_url', CORONAVIRUS_UTILS__DEFAULT_GMUCF_URL );
+	$gmucf_url      = Config\get_gmucf_email_url();
 
 	if ( ! $current_screen || $current_screen->id !== $menu_id ) return;
 ?>
@@ -142,9 +143,13 @@ function insert_instant_send_js() {
 		var data = {
 			action: 'instant-send'
 		};
-		var gmucf_url = '<?php echo $gmucf_url; ?>';
+		var gmucfUrl = '<?php echo $gmucf_url; ?>';
+		var $sendBtn = $('#instant-send');
+		var $spinner = $('<img src="<?php echo admin_url( '/images/wpspin_light.gif' ); ?>" alt="Processing..." style="margin-left: 6px; display: inline-block; vertical-align: sub;">');
 
 		var onPostSuccess = function(response) {
+			$spinner.remove();
+
 			var $markup = '';
 			if ( response.success === true ) {
 				$markup = $(
@@ -163,7 +168,8 @@ function insert_instant_send_js() {
 			$markup.insertAfter('.acf-settings-wrap > h1');
 		};
 
-		$('#instant-send').on('click', function() {
+		$sendBtn.on('click', function() {
+			$sendBtn.append($spinner);
 			$.post(
 				ajaxurl,
 				data,
@@ -173,8 +179,7 @@ function insert_instant_send_js() {
 		});
 
 		$(document).on('ready', function() {
-			console.log('hello?');
-			$('#preview-in-browser').attr('href', gmucf_url);
+			$('#preview-in-browser').attr('href', gmucfUrl);
 		});
 	}(jQuery));
 	</script>

--- a/includes/config.php
+++ b/includes/config.php
@@ -56,3 +56,20 @@ function define_customizer_fields( $wp_customize ) {
 }
 
 add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_fields' );
+
+
+/**
+ * Returns the URL for the coronavirus email relative
+ * to this site's environment.
+ *
+ * @since 1.1.0
+ * @author Jo Dickson
+ * @return string
+ */
+function get_gmucf_email_url() {
+	$retval = CORONAVIRUS_UTILS__DEFAULT_GMUCF_URL;
+	if ( defined( 'CORONAVIRUS_THEME_CUSTOMIZER_PREFIX' ) ) {
+		$retval = get_option( CORONAVIRUS_THEME_CUSTOMIZER_PREFIX . 'email_gmucf_url', CORONAVIRUS_UTILS__DEFAULT_GMUCF_URL );
+	}
+	return $retval;
+}

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Custom configuration settings for the Coronavirus
+ * site go here
+ */
+namespace Coronavirus\Utils\Includes\Config;
+
+
+/**
+ * Defines sections used in the WordPress Customizer.
+ *
+ * @since 1.1.0
+ * @author Jo Dickson
+ */
+function define_customizer_sections( $wp_customize ) {
+	if ( defined( 'CORONAVIRUS_THEME_CUSTOMIZER_PREFIX' ) ) {
+		$wp_customize->add_section(
+			CORONAVIRUS_THEME_CUSTOMIZER_PREFIX . 'emails',
+			array(
+				'title' => 'Weekly Emails'
+			)
+		);
+	}
+}
+
+add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_sections' );
+
+
+/**
+ * Defines settings and controls used in the WordPress Customizer.
+ *
+ * @since 1.1.0
+ * @author Jo Dickson
+ */
+function define_customizer_fields( $wp_customize ) {
+	if ( defined( 'CORONAVIRUS_THEME_CUSTOMIZER_PREFIX' ) ) {
+		// Weekly Emails
+		$wp_customize->add_setting(
+			CORONAVIRUS_THEME_CUSTOMIZER_PREFIX . 'email_gmucf_url',
+			array(
+				'default' => CORONAVIRUS_UTILS__DEFAULT_GMUCF_URL,
+				'type'    => 'option'
+			)
+		);
+
+		$wp_customize->add_control(
+			CORONAVIRUS_THEME_CUSTOMIZER_PREFIX . 'email_gmucf_url',
+			array(
+				'type'        => 'url',
+				'label'       => 'Coronavirus Email on GMUCF',
+				'description' => 'URL to the generated Coronavirus email markup on GMUCF on this environment.',
+				'section'     => CORONAVIRUS_THEME_CUSTOMIZER_PREFIX . 'emails'
+			)
+		);
+	}
+}
+
+add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_fields' );

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -4,6 +4,7 @@
  * sending weekly email markup
  */
 namespace Coronavirus\Utils\Includes\EmailSend;
+use Coronavirus\Utils\Includes\Config;
 
 
 /**
@@ -68,7 +69,16 @@ function content_type( $content_type ) {
  * @return string
  */
 function retrieve_email_markup() {
-	return 'TODO';
+	$url           = Config\get_gmucf_email_url();
+	$response      = wp_remote_get( $url, array( 'timeout' => 15 ) );
+	$response_code = wp_remote_retrieve_response_code( $response );
+	$result        = false;
+
+	if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
+		$result = wp_remote_retrieve_body( $response );
+	}
+
+	return $result;
 }
 
 

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Provides the functions necessary for instantly
+ * sending weekly email markup
+ */
+namespace Coronavirus\Utils\Includes\EmailSend;
+
+
+/**
+ * Properly formats incoming arguments
+ * to send an email from WordPress
+ *
+ * @author Jim Barnes
+ * @since 1.1.0
+ * @param array $args The argument array
+ * @return bool True if the email was sent.
+ */
+function send_instant_preview( $args ) {
+	$args = shortcode_atts(
+		array(
+			'to'            => array( 'webcom@ucf.edu' ),
+			'subject'       => '**PREVIEW** Test Email **PREVIEW**',
+			'from_friendly' => 'Coronavirus Site Admin',
+			'from'          => 'webcom@ucf.edu',
+			'body'          => 'Hello World',
+		),
+		$args
+	);
+
+	$headers = array();
+
+	$from_friendly = $args['from_friendly'];
+	$from_email    = $args['from'];
+
+	$sender = "From: $from_friendly <$from_email>";
+
+	$headers[] = 'MIME-Version: 1.0';
+	$headers[] = 'Content-Type: text/html; charset=UTF-8';
+	$headers[] = $sender;
+
+	return wp_mail(
+		$args['to'],
+		trim( $args['subject'] ),
+		trim( $args['body'] ),
+		$headers
+	);
+}
+
+
+/**
+ * Helper function for text/html issues
+ *
+ * @author Jim Barnes
+ * @since 1.1.0
+ * @param string $content_type
+ * @return string
+ */
+function content_type( $content_type ) {
+	return 'text/html';
+}
+
+
+/**
+ * Retrieves email markup to send within a test.
+ *
+ * @author Jo Dickson
+ * @since 1.1.0
+ * @return string
+ */
+function retrieve_email_markup() {
+	return 'TODO';
+}
+
+
+/**
+ * Sanitizes a preview recipient's email address to ensure
+ * errant spaces are removed around the address, and that
+ * consistent lowercase letters are used.
+ *
+ * @author Jo Dickson
+ * @since 1.1.0
+ * @param string $recipient_email A preview recipient's email address
+ * @return string Sanitized recipient's email address
+ */
+function sanitize_recipient_email( $recipient_email ) {
+	return strtolower( trim( $recipient_email ) );
+}
+
+
+/**
+ * Retrieves coronavirus email markup and sends a test
+ * with that markup instantly.
+ *
+ * @author Jim Barnes
+ * @since 1.1.0
+ * @return bool Whether the email contents were sent successfully
+ */
+function instant_send() {
+	$markup = retrieve_email_markup();
+
+	$args = array(
+		'body' => $markup
+	);
+
+	// Get recipients
+	$preview_recipients_raw = get_field( 'preview_recipients', 'options_weekly_email' );
+	$recipients = explode( ',', $preview_recipients_raw ) ?: array();
+	$recipients = array_unique( array_filter( array_map( __NAMESPACE__ . '\sanitize_recipient_email', $recipients ) ) );
+
+	if ( count( $recipients ) > 0 ) {
+		$args['to'] = $recipients;
+	}
+
+	// Get subject line and from details
+	$subject       = 'In Case You Missed It: UCF COVID-19 Updates';
+	$from_email    = 'feedback@ucf.edu';
+	$from_friendly = 'University of Central Florida';
+
+	if ( $subject ) {
+		$args['subject'] = "*** PREVIEW *** $subject *** PREVIEW ***";
+	}
+
+	if ( $from_email && $from_friendly ) {
+		$args['from']          = $from_email;
+		$args['from_friendly'] = $from_friendly;
+	}
+
+	$send = send_instant_preview( $args );
+
+	return $send;
+}
+
+
+/**
+ * The ajax handler for coronavirus email instant sends.
+ *
+ * @author Jim Barnes
+ * @since 1.10
+ */
+function instant_send_ajax() {
+	$send = instant_send();
+
+	$retval = array(
+		'success' => $send
+	);
+
+	echo json_encode( $retval );
+
+	wp_die();
+}
+
+add_action( 'wp_ajax_instant-send', __NAMESPACE__ . '\instant_send_ajax', 10 );

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -145,7 +145,7 @@ function instant_send() {
  * The ajax handler for coronavirus email instant sends.
  *
  * @author Jim Barnes
- * @since 1.10
+ * @since 1.1.0
  */
 function instant_send_ajax() {
 	$send = instant_send();


### PR DESCRIPTION
<!---
Thank you for contributing to Coronavirus-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Coronavirus-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds a button to the ICYMI email builder for sending email tests directly from the builder interface, as well as a field for defining preview recipients.

The Send Test button code is largely copied over from the GMUCF Utils plugin, with some minor adjustments.

**Note**: I'm going to add a separate issue to make the preview subject line and "from" details editable in the customizer.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To allow the content team to send email previews themselves.  Resolves #8 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
