### PR TITLE
Email builder - editable test email details; plugin option default registration

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -134,7 +134,7 @@ add_filter( 'quicktags_settings', __NAMESPACE__ . '\acf_wysiwyg_quicktags_toolba
 function insert_instant_send_js() {
 	$menu_id        = OptionsWeeklyEmail\screen_id();
 	$current_screen = get_current_screen();
-	$gmucf_url      = Config\get_gmucf_email_url();
+	$gmucf_url      = get_option( CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_gmucf_url' );
 
 	if ( ! $current_screen || $current_screen->id !== $menu_id ) return;
 ?>

--- a/includes/config.php
+++ b/includes/config.php
@@ -8,7 +8,10 @@ namespace Coronavirus\Utils\Includes\Config;
 
 define( 'CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX', defined( 'CORONAVIRUS_THEME_CUSTOMIZER_PREFIX' ) ? CORONAVIRUS_THEME_CUSTOMIZER_PREFIX : 'ucfcoronavirus_' );
 define( 'CORONAVIRUS_UTILS__CUSTOMIZER_DEFAULTS', serialize( array(
-	'email_gmucf_url' => 'https://gmucf.smca.ucf.edu/coronavirus/mail/?no_cache=true',
+	'email_gmucf_url'          => 'https://gmucf.smca.ucf.edu/coronavirus/mail/?no_cache=true',
+	'email_test_subject_line'  => 'In Case You Missed It: UCF COVID-19 Updates',
+	'email_test_from_address'  => 'feedback@ucf.edu',
+	'email_test_from_friendly' => 'University of Central Florida'
 ) ) );
 
 
@@ -120,6 +123,60 @@ function define_customizer_fields( $wp_customize ) {
 			'type'        => 'url',
 			'label'       => 'Coronavirus Email on GMUCF',
 			'description' => 'URL to the generated Coronavirus email markup on GMUCF on this environment.',
+			'section'     => CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'emails'
+		)
+	);
+
+	$wp_customize->add_setting(
+		CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_subject_line',
+		array(
+			'default' => get_option_default( 'email_test_subject_line' ),
+			'type'    => 'option'
+		)
+	);
+
+	$wp_customize->add_control(
+		CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_subject_line',
+		array(
+			'type'        => 'text',
+			'label'       => 'Test Email Subject Line',
+			'description' => 'The subject line to use on Coronavirus email tests.',
+			'section'     => CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'emails'
+		)
+	);
+
+	$wp_customize->add_setting(
+		CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_from_address',
+		array(
+			'default' => get_option_default( 'email_test_from_address' ),
+			'type'    => 'option'
+		)
+	);
+
+	$wp_customize->add_control(
+		CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_from_address',
+		array(
+			'type'        => 'text',
+			'label'       => 'Test Email From Address',
+			'description' => 'The "from" email address to use on Coronavirus email tests.',
+			'section'     => CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'emails'
+		)
+	);
+
+	$wp_customize->add_setting(
+		CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_from_friendly',
+		array(
+			'default' => get_option_default( 'email_test_from_friendly' ),
+			'type'    => 'option'
+		)
+	);
+
+	$wp_customize->add_control(
+		CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_from_friendly',
+		array(
+			'type'        => 'text',
+			'label'       => 'Test Email From Friendly Name',
+			'description' => 'The friendly "from" name to use on Coronavirus email tests.',
 			'section'     => CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'emails'
 		)
 	);

--- a/includes/config.php
+++ b/includes/config.php
@@ -40,6 +40,9 @@ function init() {
 	// Enforce default option values when `get_option()` is called.
 	$options = unserialize( CORONAVIRUS_UTILS__CUSTOMIZER_DEFAULTS );
 	foreach ( $options as $option_name => $option_default ) {
+		// Apply our plugin prefix to the option name:
+		$option_name = CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . $option_name;
+
 		// Enforce a default value for options we've defined
 		// defaults for:
 		add_filter( "default_option_$option_name", function( $get_option_default, $option, $passed_default ) use ( $option_default ) {

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -69,7 +69,7 @@ function content_type( $content_type ) {
  * @return string
  */
 function retrieve_email_markup() {
-	$url           = Config\get_gmucf_email_url();
+	$url           = get_option( CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_gmucf_url' );
 	$response      = wp_remote_get( $url, array( 'timeout' => 15 ) );
 	$response_code = wp_remote_retrieve_response_code( $response );
 	$result        = false;

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -122,9 +122,9 @@ function instant_send() {
 	}
 
 	// Get subject line and from details
-	$subject       = 'In Case You Missed It: UCF COVID-19 Updates';
-	$from_email    = 'feedback@ucf.edu';
-	$from_friendly = 'University of Central Florida';
+	$subject       = get_option( CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_subject_line' );
+	$from_email    = get_option( CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_from_address' );
+	$from_friendly = get_option( CORONAVIRUS_UTILS__CUSTOMIZER_PREFIX . 'email_test_from_friendly' );
 
 	if ( $subject ) {
 		$args['subject'] = "*** PREVIEW *** $subject *** PREVIEW ***";


### PR DESCRIPTION
<!---
Thank you for contributing to Coronavirus-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Coronavirus-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added customizer fields for editing the ICYMI email tests' subject line and "from" details.
- Set up logic for registering plugin option defaults and returning them when appropriate via `get_option()`.  (This code is pretty much copied directly from the GMUCF theme)

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #11 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
